### PR TITLE
Add pause menu functionality to Office Defense

### DIFF
--- a/Assets/Code/InGameMenuController.cs
+++ b/Assets/Code/InGameMenuController.cs
@@ -1,0 +1,82 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UIElements;
+
+public class InGameMenuController : MonoBehaviour
+{
+    private VisualElement root; // Root of the UIDocument
+    private Button resumeButton;
+    private Button restartButton;
+    private Button quitButton;
+    private bool isPaused = false;
+
+    private UIDocument uiDocument;
+
+    void Start()
+    {
+        // Get reference to the UIDocument and its root
+        uiDocument = GetComponent<UIDocument>();
+        root = uiDocument.rootVisualElement;
+
+        // Assign buttons from the UI
+        resumeButton = root.Q<Button>("ResumeButton");
+        restartButton = root.Q<Button>("RestartButton");
+        quitButton = root.Q<Button>("QuitButton");
+
+        // Hook up button click events
+        resumeButton.clicked += ResumeGame;
+        restartButton.clicked += RestartLevel;
+        quitButton.clicked += QuitToMainMenu;
+
+        // Ensure the UI starts hidden
+        root.style.display = DisplayStyle.None;
+    }
+
+    void Update()
+    {
+        // Toggle pause menu with the 'Esc' key
+        if (Input.GetKeyDown(KeyCode.Escape))
+        {
+            if (isPaused)
+            {
+                ResumeGame();
+            }
+            else
+            {
+                PauseGame();
+            }
+        }
+    }
+
+    // Pause the game
+    public void PauseGame()
+    {
+        root.style.display = DisplayStyle.Flex; // Show the UI
+        Time.timeScale = 0f; // Stop the game time
+        isPaused = true;
+    }
+
+    // Resume the game
+    public void ResumeGame()
+    {
+        root.style.display = DisplayStyle.None; // Hide the UI
+        Time.timeScale = 1f; // Resume the game time
+        isPaused = false;   
+    }
+
+    // Restart the current level
+    public void RestartLevel()
+    {
+        Time.timeScale = 1f; // Ensure game time resumes
+        SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+    }
+
+    // Quit to the main menu
+    public void QuitToMainMenu()
+    {
+        Time.timeScale = 1f; // Ensure game time resumes
+        SceneManager.LoadScene("TitleScreen"); // Replace with your actual main menu scene name
+    }
+}

--- a/Assets/Code/InGameMenuController.cs.meta
+++ b/Assets/Code/InGameMenuController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2eb68ed286758549b42cf031ef8d512
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/LevelOne.unity
+++ b/Assets/Scenes/LevelOne.unity
@@ -2035,6 +2035,67 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1335387981}
   m_CullTransparentMesh: 1
+--- !u!1 &1361874424
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1361874425}
+  - component: {fileID: 1361874426}
+  - component: {fileID: 1361874427}
+  m_Layer: 0
+  m_Name: InGameMenu
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1361874425
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1361874424}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 481, y: 270.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1361874426
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1361874424}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 19102, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_PanelSettings: {fileID: 11400000, guid: 79b0950f34e7a0d4889d4b3e3870e63d, type: 2}
+  m_ParentUI: {fileID: 0}
+  sourceAsset: {fileID: 9197481963319205126, guid: ef43893dbccdd6b43aa1f36fab1662b7, type: 3}
+  m_SortingOrder: 0
+--- !u!114 &1361874427
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1361874424}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b2eb68ed286758549b42cf031ef8d512, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1476476153
 GameObject:
   m_ObjectHideFlags: 0
@@ -3376,3 +3437,4 @@ SceneRoots:
   - {fileID: 632190540}
   - {fileID: 1604513841}
   - {fileID: 1952072852}
+  - {fileID: 1361874425}

--- a/Assets/Scenes/TitleScreen.unity
+++ b/Assets/Scenes/TitleScreen.unity
@@ -341,7 +341,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1998590564}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8d86e7d23c40cf04da79df932477e85b, type: 3}
+  m_Script: {fileID: 11500000, guid: 1a66ba6fe3ba1ce4e94a27ab22d8ff16, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1660057539 &9223372036854775807

--- a/Assets/UI Toolkit/InGameMenuVisualTree.uxml
+++ b/Assets/UI Toolkit/InGameMenuVisualTree.uxml
@@ -1,0 +1,19 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <ui:VisualElement name="VisualElement" style="flex-grow: 1; background-color: rgba(0, 0, 0, 0.58); -unity-background-scale-mode: scale-to-fit; background-image: none; position: absolute; top: 0; left: 0; right: 0; bottom: 0;" />
+    <ui:VisualElement style="flex-grow: 1; position: relative; left: 0; top: 0; right: 0; bottom: 0;">
+        <ui:VisualElement name="VisualElement" style="flex-grow: 1; background-color: rgb(22, 22, 22); align-self: center; align-items: center; width: 50%; height: auto; justify-content: center; margin-top: 16%; margin-bottom: 16%; border-top-left-radius: 6px; border-top-right-radius: 6px; border-bottom-right-radius: 6px; border-bottom-left-radius: 6px;">
+            <ui:VisualElement style="flex-grow: 1; justify-content: center; align-self: center; align-items: center; flex-direction: column; flex-wrap: nowrap;">
+                <ui:VisualElement style="flex-grow: 1; justify-content: center; align-self: auto;">
+                    <ui:Button text="RESUME" parse-escape-sequences="true" display-tooltip-when-elided="true" name="ResumeButton" style="font-size: 17px; width: 200px; height: 60px; border-top-left-radius: 6px; border-top-right-radius: 6px; border-bottom-right-radius: 6px; border-bottom-left-radius: 6px; background-color: rgb(18, 120, 157); color: rgb(255, 255, 255); -unity-font-style: bold; margin-top: 5px; margin-right: 0; margin-bottom: 5px; margin-left: 0;" />
+                    <ui:Button text="RESTART" parse-escape-sequences="true" display-tooltip-when-elided="true" name="RestartButton" style="font-size: 17px; width: 200px; height: 60px; border-top-left-radius: 6px; border-top-right-radius: 6px; border-bottom-right-radius: 6px; border-bottom-left-radius: 6px; background-color: rgb(18, 120, 157); color: rgb(255, 255, 255); -unity-font-style: bold; text-overflow: ellipsis; margin-top: 5px; margin-right: 0; margin-bottom: 5px; margin-left: 0;" />
+                    <ui:Button text="QUIT" parse-escape-sequences="true" display-tooltip-when-elided="true" name="QuitButton" style="font-size: 17px; width: 200px; height: 60px; border-top-left-radius: 6px; border-top-right-radius: 6px; border-bottom-right-radius: 6px; border-bottom-left-radius: 6px; background-color: rgb(18, 120, 157); color: rgb(255, 255, 255); -unity-font-style: bold; margin-top: 5px; margin-right: 0; margin-bottom: 5px; margin-left: 0;" />
+                </ui:VisualElement>
+            </ui:VisualElement>
+        </ui:VisualElement>
+        <ui:VisualElement name="VisualElement" style="flex-grow: 1; position: absolute; align-items: center; justify-content: flex-start; align-self: center; height: -35px; margin-top: 14%; margin-bottom: 14%;">
+            <ui:VisualElement name="VisualElement" style="flex-grow: 1; position: relative; left: auto; right: auto; top: auto; justify-content: flex-start; align-items: center; height: auto; transform-origin: center; width: auto; bottom: auto; align-self: center;">
+                <ui:Label tabindex="-1" text="PAUSE" parse-escape-sequences="true" display-tooltip-when-elided="true" name="PauseLabel" style="font-size: 40px; -unity-font-style: normal; color: rgb(255, 255, 255); -unity-text-align: upper-center; -unity-text-outline-width: 8px; -unity-text-outline-color: rgb(255, 255, 255); letter-spacing: 6px; -unity-font: initial; align-self: center; justify-content: flex-start; align-items: center; height: 16px;" />
+            </ui:VisualElement>
+        </ui:VisualElement>
+    </ui:VisualElement>
+</ui:UXML>

--- a/Assets/UI Toolkit/InGameMenuVisualTree.uxml.meta
+++ b/Assets/UI Toolkit/InGameMenuVisualTree.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: ef43893dbccdd6b43aa1f36fab1662b7
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}


### PR DESCRIPTION
- Created a UI for the in-game pause menu using UIDocument and UIToolkit.
- Implemented scripting to:
   - Pause the game and display the menu when the 'Esc' key is pressed.
   - Resume the game without resetting player stats (health, score, etc.).
   - Restart the current level.
   - Quit to the title menu.
- Added a missing script to the title menu to ensure proper navigation and functionality.